### PR TITLE
Fix Metroid Prime 1 X-Ray visor VR handling

### DIFF
--- a/Data/Sys/GameSettingsVR/GM8E01.ini
+++ b/Data/Sys/GameSettingsVR/GM8E01.ini
@@ -26,6 +26,7 @@ texture=98d66e7812c70dd8
 texture=bb21e8755f36b2f0
 [ElementsGroupOverride_Enable]
 $Metroid Profile HUD and Visor
+$Metroid Profile X-Ray Screen Effects
 $Metroid Profile Screen Effects
 $Metroid Profile Hidden Layers
 $Black Box on the Left Side
@@ -51,19 +52,24 @@ profile_layer=METROID_VISOR
 profile_layer=METROID_VISOR_BOOTUP
 profile_layer=METROID_UNKNOWN_HUD
 
+$Metroid Profile X-Ray Screen Effects
+format=element_profile_v1
+handling=fullscreen_mono
+profile=metroid_prime_1_gc
+profile_layer=METROID_XRAY_EFFECT
+profile_layer=METROID_VISOR_DIRT
+
 $Metroid Profile Screen Effects
 format=element_profile_v1
 handling=fullscreen_mono
 profile=metroid_prime_1_gc
 profile_layer=METROID_SCREEN_OVERLAY
-profile_layer=METROID_XRAY_EFFECT
 profile_layer=METROID_THERMAL_EFFECT
 profile_layer=METROID_THERMAL_EFFECT_GUN
 profile_layer=METROID_CHARGE_BEAM_EFFECT
 profile_layer=METROID_SCREEN_FADE
 profile_layer=METROID_ECHO_EFFECT
 profile_layer=METROID_DARK_EFFECT
-profile_layer=METROID_VISOR_DIRT
 profile_layer=METROID_SCAN_HIGHLIGHTER
 profile_layer=METROID_SCAN_DARKEN
 
@@ -111,7 +117,7 @@ sig_blend_alpha=1
 
 $X-Ray
 format=element_only_v5
-handling=fullscreen
+handling=fullscreen_mono
 sig_perspective=0
 sig_persp_hfov=0
 sig_persp_vfov=0
@@ -145,7 +151,7 @@ sig_blend_alpha=1
 
 $X-Ray when walking
 format=element_only_v5
-handling=fullscreen
+handling=fullscreen_mono
 sig_perspective=0
 sig_persp_hfov=0
 sig_persp_vfov=0


### PR DESCRIPTION
Fixed the issue of the X-ray being detached from the screen with your new HUD changes